### PR TITLE
Add support for datasets with no "modalities" key

### DIFF
--- a/src/multimeditron/dataset/sample_preprocessor.py
+++ b/src/multimeditron/dataset/sample_preprocessor.py
@@ -99,7 +99,7 @@ class SamplePreprocessor:
             processed_sample = sample.copy()
             processed_sample[MODALITIES_KEY] = []
 
-            for modality in sample[MODALITIES_KEY]:
+            for modality in sample.get(MODALITIES_KEY, []):
                 processed_sample[MODALITIES_KEY].append(
                     self.modality_processors[modality[MODALITY_TYPE_KEY]].process(modality)
                 )


### PR DESCRIPTION
This pull request introduces several improvements to the training pipeline and dataset preprocessing in the `multimeditron` project. The main changes include supporting loading datasets from `.jsonl` files, enhancing the model initialization logic to use DeepSpeed's zero initialization, and making the sample preprocessing more robust to missing modalities.

**Dataset Loading Enhancements:**
* Added support for loading datasets directly from `.jsonl` files using the new `is_jsonl` helper and updated the dataset loading logic in `build_datasets` to handle this format. [[1]](diffhunk://#diff-39af14b36ef4012b09f399aa24a53f0c3d55c9d3adc97c867fd933a3899b5b22R31-R34) [[2]](diffhunk://#diff-39af14b36ef4012b09f399aa24a53f0c3d55c9d3adc97c867fd933a3899b5b22R44-R45)

**Training Pipeline Improvements:**
* Refactored model initialization in `train.py` to use DeepSpeed's zero initialization context (`deepspeed.zero.Init`) with `torch.bfloat16`, improving memory efficiency during model creation. [[1]](diffhunk://#diff-39af14b36ef4012b09f399aa24a53f0c3d55c9d3adc97c867fd933a3899b5b22R11) [[2]](diffhunk://#diff-39af14b36ef4012b09f399aa24a53f0c3d55c9d3adc97c867fd933a3899b5b22R89-L107)
* Simplified the conditional logic for constructing the model: if a `base_model` is provided, it now loads the model directly with additional configuration options like `truncation` and `max_sequence_length`.

**Sample Preprocessing Robustness:**
* Updated the modality processing loop to use `sample.get(MODALITIES_KEY, [])`, preventing errors when the modalities key is missing from a sample.