### PR TITLE
END2END training config

### DIFF
--- a/config/config_endtoend.yaml
+++ b/config/config_endtoend.yaml
@@ -1,10 +1,10 @@
 base_llm: meta-llama/Llama-3.1-8B-Instruct
-base_model: /capstor/store/cscs/swissai/a127/homes/mzoghlam/models/alignment-1D/checkpoint-1620
+base_model: /capstor/store/cscs/swissai/a127/homes/$USER/models/alignment/checkpoint-1620 # Update path to your own
 attachment_token: <|reserved_special_token_0|>
 tokenizer_type: llama
 token_size: 4096
-truncation: true
-max_seq_length: 4096
+truncation: true # important to avoid OOM Error
+max_seq_length: 4096 # important to avoid OOM Error
 
 loaders:
   - loader_type: raw-image
@@ -32,16 +32,16 @@ datasets:
   - packed_path: /capstor/store/cscs/swissai/a127/meditron/multimediset/arrow/image_mammoth
 
 training_args:
-  output_dir: /capstor/store/cscs/swissai/a127/homes/mzoghlam/models/endtoend-1D
+  output_dir: /capstor/store/cscs/swissai/a127/homes/$USER/models/endtoend-1D
   dataloader_num_workers: 16  # > 0 not supported for IterableDataset, cf. https://github.com/huggingface/datasets/issues/5984
   dataloader_prefetch_factor: 4
   remove_unused_columns: false
-  ddp_find_unused_parameters: false # Test to reduce memory 
+  ddp_find_unused_parameters: false 
   learning_rate: 1.0e-4
   bf16: true 
-  per_device_train_batch_size: 1 # Initially 4  # note that training_args.n_gpu and training_args.train_batch_size show faulty values
+  per_device_train_batch_size: 1  # note that training_args.n_gpu and training_args.train_batch_size show faulty values
                                   # with deepspeed -> use deepspeed_plugin instead (besides training_args.distributed_state.num_processes == WORLD_SIZE)
-  gradient_accumulation_steps: 8 #intially 8
+  gradient_accumulation_steps: 8 
   num_train_epochs: 10
   gradient_checkpointing: true
   gradient_checkpointing_kwargs:
@@ -49,8 +49,8 @@ training_args:
   save_strategy: steps
   save_steps: 0.25
   max_grad_norm: 1.0
-  run_name: MultiMeditron-Llama-8B-end2end-1D     # Set the name for the run
-  deepspeed: /users/mzoghlam/MultiMeditron/config/deepspeed.json
+  run_name: MultiMeditron-Llama-8B-end2end
+  deepspeed: /users/$USER/MultiMeditron/config/deepspeed.json # Update path to your own
   accelerator_config:
     dispatch_batches: false
   lr_scheduler_type: "cosine_with_min_lr"


### PR DESCRIPTION
Added a `.yaml` config file for the END2END Multimeditron training. This configuration should launch a training with no CUDA Out Of Memory Errors.