### PR TITLE
Attempt to fix the part about downloading the data in the cookbook

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -147,18 +147,18 @@ source .env
 The data is available on huggingface at [OpenMeditron/MultiMediset](https://huggingface.co/datasets/OpenMeditron/MultiMediset). You can download the data by running:
 
 ```py
-from datasets import load_dataset
+from datasets import load_dataset, get_dataset_config_names
 import os
 
 STORAGE_ROOT = os.environ["STORAGE_ROOT"]
-DS_NUM_PROC = os.environ["DS_NUM_PROC"]
+DS_NUM_PROC = int(os.environ["DS_NUM_PROC"])
 
 dataset_name = "OpenMeditron/MultiMediset"
+configs = get_dataset_config_names(dataset_name)
 
-ds_dict = load_dataset(dataset_name, num_proc=DS_NUM_PROC)
-
-for split_name, split_dataset in ds_dict.items():
+for split_name in configs:
     split_dir = os.path.join(STORAGE_ROOT, split_name)
+    split_dataset = load_dataset(dataset_name, split_name, num_proc=DS_NUM_PROC)
     split_dataset.save_to_disk(split_dir)
 ```
 

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -142,7 +142,7 @@ In your terminal, run:
 source .env
 ```
 
-### Download data
+### Download data (optional if you are part of the LiGHT organization in the CSCS)
 
 The data is available on huggingface at [OpenMeditron/MultiMediset](https://huggingface.co/datasets/OpenMeditron/MultiMediset). You can download the data by running:
 


### PR DESCRIPTION
There are issues with some splits though: `datasets.exceptions.NonMatchingSplitsSizesError: [{'expected': SplitInfo(name='train', num_bytes=49109524, num_examples=347, shard_lengths=None, dataset_name=None), 'recorded': SplitInfo(name='train', num_bytes=0, num_examples=0, shard_lengths=None, dataset_name='multi_mediset')}]`