### PR TITLE
Native 3D medical volume modality support

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,28 @@
+MultiMeditron 3D Volume Modality — Third-Party Notices
+======================================================
+
+This module integrates pretrained 3D vision encoders and borrows
+architectural patterns from upstream projects.
+
+M3D-CLIP (3D ViT vision encoder, BERT text encoder)
+  HuggingFace: GoodBaiBai88/M3D-CLIP
+  License:     Apache-2.0
+  Paper:       arXiv 2404.00578
+
+M3D / M3D-LaMed (architectural reference)
+  Source:      https://github.com/BAAI-DCAI/M3D
+  License:     MIT
+  Note:        the 256-token spatial-pool perceiver contract used by
+               VolumeModality is borrowed from M3D-LaMed.
+
+MONAI (PatchEmbeddingBlock used by M3D-CLIP)
+  Source:      https://github.com/Project-MONAI/MONAI
+  License:     Apache-2.0
+
+LLaVA (chat-template and projector conventions, transitively via M3D)
+  Source:      https://github.com/haotian-liu/LLaVA
+  License:     Apache-2.0
+
+The M3D-CLIP pretraining data (M3D-Cap, sourced from Radiopaedia) is
+released for non-commercial machine-learning research. Downstream
+users redistributing trained derivatives must verify dataset terms.

--- a/cookbook/sft/volume_3d/llama_volume/stage1_alignment.yaml
+++ b/cookbook/sft/volume_3d/llama_volume/stage1_alignment.yaml
@@ -1,0 +1,53 @@
+base_llm: meta-llama/Llama-3.1-8B-Instruct
+base_model: null
+resume_from_checkpoint: false
+wandb_run_id: null
+attachment_token: <|reserved_special_token_0|>
+tokenizer_type: llama
+token_size: 4096
+
+loaders:
+  - loader_type: fs-volume
+    modality_type: 3d_volume
+
+modalities:
+  - model_type: volume_3d
+    hidden_size: 4096
+    clip_name: GoodBaiBai88/M3D-CLIP
+    trust_remote_code: true
+    volume_size: [32, 256, 256]
+    proj_out_num: 256
+    num_channels: 1
+
+training_mode: ALIGNMENT
+
+datasets:
+  - packed_path: $STORAGE_ROOT/ct_rate
+
+training_args:
+  output_dir: $MODEL_ROOT/volume_3d/MultiMeditron-Llama-8B-Alignment-3D/
+  dataloader_num_workers: 8
+  dataloader_prefetch_factor: 4
+  remove_unused_columns: false
+  ddp_find_unused_parameters: false
+  learning_rate: 1.0e-4
+  bf16: true
+  per_device_train_batch_size: 4
+  gradient_accumulation_steps: 8
+  num_train_epochs: 1
+  gradient_checkpointing: true
+  gradient_checkpointing_kwargs:
+    use_reentrant: true
+  save_strategy: steps
+  save_steps: 0.25
+  max_grad_norm: 1.0
+  run_name: MultiMeditron-Llama-8B-Alignment-3D
+  deepspeed: $WORKING_DIR/config/deepspeed.json
+  accelerator_config:
+    dispatch_batches: false
+  lr_scheduler_type: "cosine_with_min_lr"
+  lr_scheduler_kwargs:
+    min_lr: 3.0e-5
+  report_to: wandb
+  logging_steps: 1
+  weight_decay: 0.01

--- a/cookbook/sft/volume_3d/llama_volume/stage2_end2end.yaml
+++ b/cookbook/sft/volume_3d/llama_volume/stage2_end2end.yaml
@@ -1,0 +1,53 @@
+base_llm: meta-llama/Llama-3.1-8B-Instruct
+base_model: $MODEL_ROOT/volume_3d/MultiMeditron-Llama-8B-Alignment-3D/
+resume_from_checkpoint: false
+wandb_run_id: null
+attachment_token: <|reserved_special_token_0|>
+tokenizer_type: llama
+token_size: 4096
+
+loaders:
+  - loader_type: fs-volume
+    modality_type: 3d_volume
+
+modalities:
+  - model_type: volume_3d
+    hidden_size: 4096
+    clip_name: GoodBaiBai88/M3D-CLIP
+    trust_remote_code: true
+    volume_size: [32, 256, 256]
+    proj_out_num: 256
+    num_channels: 1
+
+training_mode: END2END
+
+datasets:
+  - packed_path: $STORAGE_ROOT/ct_rate
+
+training_args:
+  output_dir: $MODEL_ROOT/volume_3d/MultiMeditron-Llama-8B-End2End-3D/
+  dataloader_num_workers: 8
+  dataloader_prefetch_factor: 4
+  remove_unused_columns: false
+  ddp_find_unused_parameters: false
+  learning_rate: 2.0e-5
+  bf16: true
+  per_device_train_batch_size: 2
+  gradient_accumulation_steps: 16
+  num_train_epochs: 2
+  gradient_checkpointing: true
+  gradient_checkpointing_kwargs:
+    use_reentrant: true
+  save_strategy: steps
+  save_steps: 0.25
+  max_grad_norm: 1.0
+  run_name: MultiMeditron-Llama-8B-End2End-3D
+  deepspeed: $WORKING_DIR/config/deepspeed.json
+  accelerator_config:
+    dispatch_batches: false
+  lr_scheduler_type: "cosine_with_min_lr"
+  lr_scheduler_kwargs:
+    min_lr: 5.0e-6
+  report_to: wandb
+  logging_steps: 1
+  weight_decay: 0.01

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,9 @@ dependencies = [
     "benchy @ git+https://github.com/lukasgd/benchy.git@slurm",
     "datasets @ git+https://github.com/Androz2091/simon-huggingface-datasets.git",
     "gradio",
-    "open_clip_torch"
+    "open_clip_torch",
+    "nibabel",
+    "monai>=1.4"
 ]
 
 [project.optional-dependencies]

--- a/scripts/demo_3d_volume.py
+++ b/scripts/demo_3d_volume.py
@@ -1,0 +1,44 @@
+"""
+Minimal demo: load M3D-CLIP via VolumeModality and run a synthetic volume.
+
+Run:
+    python scripts/demo_3d_volume.py
+
+This downloads ~800 MB on first run (the M3D-CLIP weights). The test
+suite (tests/test_volume_3d.py) covers the same path with a mocked
+encoder for offline / CI use.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+from multimeditron.model.constants import MODALITY_VALUE_KEY
+from multimeditron.model.modalities.volume.volume_config import VolumeConfig
+from multimeditron.model.modalities.volume.volume_modality import VolumeModality
+from multimeditron.model.modalities.volume.volume_processor import VolumeProcessor
+
+
+def main() -> None:
+    cfg = VolumeConfig()
+    print(f"loading {cfg.clip_name}")
+
+    proc = VolumeProcessor(cfg)
+    mod = VolumeModality(cfg).eval()
+
+    raw = np.random.rand(1, 64, 64, 32).astype(np.float32)
+    print(f"synthetic input: {raw.shape}")
+
+    processed = proc.process({MODALITY_VALUE_KEY: raw, "type": "3d_volume"})
+    tensor = processed[MODALITY_VALUE_KEY]
+    print(f"after processor: {tuple(tensor.shape)} dtype={tensor.dtype}")
+
+    with torch.no_grad():
+        embeds = mod([tensor])
+    print(f"after modality:  {tuple(embeds.shape)} dtype={embeds.dtype}")
+    print(f"expected:        (1, {cfg.proj_out_num}, {cfg.hidden_size})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval_3d_volume_retrieval.py
+++ b/scripts/eval_3d_volume_retrieval.py
@@ -1,0 +1,93 @@
+"""
+Zero-shot image-text retrieval sanity check for the M3D-CLIP backend.
+
+Loads M3D-CLIP, embeds (volume, caption) pairs from a user-provided
+CSV, and reports R@1 / R@5 / R@10. The published baseline on the
+M3D-Cap 2k-sample test split is R@1 = 19.10 (M3D-LaMed paper,
+arXiv 2404.00578, Table 1).
+
+Usage:
+    python scripts/eval_3d_volume_retrieval.py \\
+        --pairs path/to/pairs.csv \\
+        --base-path path/to/volumes/
+
+The CSV must have header ``volume,caption``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+
+import nibabel as nib
+import numpy as np
+import torch
+import torch.nn.functional as F
+from transformers import AutoModel, AutoTokenizer
+
+from multimeditron.model.modalities.volume.volume_modality import (
+    _patch_monai_for_m3dclip,
+)
+
+
+def load_volume(path: Path, target=(32, 256, 256)) -> torch.Tensor:
+    arr = nib.load(str(path)).get_fdata().astype(np.float32)
+    if arr.ndim == 3:
+        arr = arr[None]
+    t = torch.from_numpy(arr).unsqueeze(0)
+    t = F.interpolate(t, size=target, mode="trilinear", align_corners=False)
+    vmin, vmax = t.min(), t.max()
+    return (t - vmin) / (vmax - vmin).clamp_min(1e-6)
+
+
+def recall_at_k(sim: torch.Tensor, k: int) -> float:
+    n = sim.size(0)
+    topk = sim.topk(k, dim=1).indices
+    targets = torch.arange(n).unsqueeze(1)
+    return (topk == targets).any(dim=1).float().mean().item()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--pairs", type=Path, required=True)
+    ap.add_argument("--base-path", type=Path, default=Path("."))
+    ap.add_argument("--clip-name", default="GoodBaiBai88/M3D-CLIP")
+    ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    args = ap.parse_args()
+
+    _patch_monai_for_m3dclip()
+    tok = AutoTokenizer.from_pretrained(
+        args.clip_name, model_max_length=512, padding_side="right", use_fast=False
+    )
+    model = AutoModel.from_pretrained(
+        args.clip_name, trust_remote_code=True
+    ).to(args.device).eval()
+
+    img_feats, txt_feats = [], []
+    with open(args.pairs) as f:
+        rows = list(csv.DictReader(f))
+
+    with torch.inference_mode():
+        for row in rows:
+            vol = load_volume(args.base_path / row["volume"]).to(args.device)
+            img = model.encode_image(vol)[:, 0]
+            txt_in = tok(
+                row["caption"], max_length=512, truncation=True,
+                padding="max_length", return_tensors="pt",
+            ).to(args.device)
+            txt = model.encode_text(txt_in["input_ids"], txt_in["attention_mask"])[:, 0]
+            img_feats.append(F.normalize(img, dim=-1))
+            txt_feats.append(F.normalize(txt, dim=-1))
+
+    img = torch.cat(img_feats, dim=0)
+    txt = torch.cat(txt_feats, dim=0)
+    sim = img @ txt.T
+
+    print(f"pairs:  {len(rows)}")
+    for k in (1, 5, 10):
+        print(f"R@{k:<2}:   {recall_at_k(sim, k) * 100:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/multimeditron/dataset/loader/__init__.py
+++ b/src/multimeditron/dataset/loader/__init__.py
@@ -156,11 +156,13 @@ class AutoModalityLoader:
 
 from multimeditron.dataset.loader.image.bytes import RawImageLoader
 from multimeditron.dataset.loader.image.fs import FileSystemImageLoader
+from multimeditron.dataset.loader.volume.volume_loader import FileSystemVolumeLoader
 
 __all__ = [
     "BaseModalityLoader",
     "AutoModalityLoader",
     "RawImageLoader",
     "FileSystemImageLoader",
+    "FileSystemVolumeLoader",
 ]
 

--- a/src/multimeditron/dataset/loader/volume/__init__.py
+++ b/src/multimeditron/dataset/loader/volume/__init__.py
@@ -1,0 +1,3 @@
+from multimeditron.dataset.loader.volume.volume_loader import FileSystemVolumeLoader
+
+__all__ = ["FileSystemVolumeLoader"]

--- a/src/multimeditron/dataset/loader/volume/volume_loader.py
+++ b/src/multimeditron/dataset/loader/volume/volume_loader.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import os
+import pathlib
+from typing import Any, Dict, Union
+
+import numpy as np
+
+from multimeditron.dataset.loader import BaseModalityLoader, AutoModalityLoader
+from multimeditron.model.constants import MODALITY_VALUE_KEY
+
+
+@AutoModalityLoader.register("fs-volume")
+class FileSystemVolumeLoader(BaseModalityLoader):
+    """
+    Loader for 3D medical volume files (NIfTI format) from the filesystem.
+
+    Expects the sample dictionary to have a "value" key containing the path to a NIfTI file (.nii or .nii.gz). 
+    Returns a numpy array of shape (C, D, H, W).
+
+    Example:
+
+    .. code-block:: python
+
+        loader = FileSystemVolumeLoader(base_path="/path/to/volumes")
+        sample = {"value": "scan.nii.gz", "type": "3d_volume"}
+        volume = loader.load(sample)
+        # volume is a numpy array of shape (1, D, H, W)
+    """
+
+    def __init__(self, base_path: Union[str, pathlib.Path] = ""):
+        """
+        Args:
+            base_path (Union[str, pathlib.Path]): The base directory where volume files are stored.
+                Defaults to empty string (absolute paths in dataset).
+        """
+        super().__init__()
+        self.base_path = base_path
+
+    def load(self, sample: Dict[str, Any]) -> np.ndarray:
+        """
+        Load a 3D medical volume from the filesystem.
+
+        Args:
+            sample (Dict[str, Any]): A dictionary containing at least the "value" key
+                with the path to the NIfTI file.
+
+        Returns:
+            np.ndarray: The loaded volume as a float32 array of shape (C, D, H, W),
+                where C=1 for single-channel scans (CT/MRI).
+        """
+        try:
+            import nibabel as nib
+        except ImportError:
+            raise ImportError(
+                "nibabel is required to load NIfTI files. "
+                "Install it with: pip install nibabel"
+            )
+
+        volume_path = os.path.join(self.base_path, sample[MODALITY_VALUE_KEY])
+
+        if not os.path.exists(volume_path):
+            raise FileNotFoundError(f"Volume file {volume_path} not found")
+
+        nii = nib.load(volume_path)
+        volume = nii.get_fdata().astype(np.float32)
+
+        # Ensure shape is (C, D, H, W) — add channel dim if needed
+        if volume.ndim == 3:
+            volume = volume[np.newaxis, ...]  # (D, H, W) → (1, D, H, W)
+        elif volume.ndim == 4:
+            # NIfTI 4D volumes store channels last: (D, H, W, C)
+            # Only transpose if last dim is small (likely channels, not spatial)
+            if volume.shape[-1] <= 4:
+                volume = np.transpose(volume, (3, 0, 1, 2))  # (D, H, W, C) → (C, D, H, W)
+            # else: already (C, D, H, W), leave as-is
+        else:
+            raise ValueError(
+                f"Expected 3D (D,H,W) or 4D (D,H,W,C) volume, got shape {volume.shape}"
+            )
+
+        return volume

--- a/src/multimeditron/model/modalities/__init__.py
+++ b/src/multimeditron/model/modalities/__init__.py
@@ -3,6 +3,9 @@ from multimeditron.model.modalities.image_modality_moe import MOEImageConfig, MO
 from multimeditron.model.modalities.image_modality_moe_pep import MOEImageConfigPEP, MOEImageModalityPEP, MOEImageProcessorPEP
 from multimeditron.model.modalities.image_modality import ImageConfig, ImageModality, ImageProcessor
 from multimeditron.model.modalities.image_modality_biomed import BioMedCLIPImageConfig, BioMedCLIPImageModality, BioMedCLIPImageProcessor
+from multimeditron.model.modalities.volume.volume_modality import VolumeModality
+from multimeditron.model.modalities.volume.volume_config import VolumeConfig
+from multimeditron.model.modalities.volume.volume_processor import VolumeProcessor
 
 __all__ = [
     "BaseModality",
@@ -21,4 +24,7 @@ __all__ = [
     "BioMedCLIPImageConfig",
     "BioMedCLIPImageModality",
     "BioMedCLIPImageProcessor",
+    "VolumeConfig",
+    "VolumeModality",
+    "VolumeProcessor",
 ]

--- a/src/multimeditron/model/modalities/volume/__init__.py
+++ b/src/multimeditron/model/modalities/volume/__init__.py
@@ -1,0 +1,5 @@
+from multimeditron.model.modalities.volume.volume_config import VolumeConfig
+from multimeditron.model.modalities.volume.volume_processor import VolumeProcessor
+from multimeditron.model.modalities.volume.volume_modality import VolumeModality
+
+__all__ = ["VolumeConfig", "VolumeProcessor", "VolumeModality"]

--- a/src/multimeditron/model/modalities/volume/volume_config.py
+++ b/src/multimeditron/model/modalities/volume/volume_config.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+from multimeditron.model.modalities.base import BaseModalityConfig
+
+
+class VolumeConfig(BaseModalityConfig):
+    """
+    Configuration for the 3D Volume Modality.
+
+    Loads a pretrained 3D vision encoder (M3D-CLIP by default) and projects
+    its patch tokens into the LLM embedding space via a parameter-free
+    spatial average pool followed by an MLP projector. The pool collapses
+    M3D-CLIP's (D/4, H/16, W/16) patch grid down to ``proj_out_num`` tokens.
+
+    Args:
+        hidden_size: LLM hidden dim (e.g. 4096 for Llama-3-8B).
+        clip_name: HuggingFace id of the pretrained 3D encoder. Default
+            ``GoodBaiBai88/M3D-CLIP`` (Apache-2.0, 3D ViT + BERT text tower).
+        trust_remote_code: Required for M3D-CLIP's custom modeling code.
+        volume_size: Target (D, H, W) after preprocessing. Must match the
+            pretrained encoder's expected input. Default (32, 256, 256)
+            matches M3D-CLIP.
+        proj_out_num: Number of LLM tokens after spatial pooling. Default
+            256 matches the M3D-LaMed perceiver contract.
+        num_channels: 1 for single-channel CT/MRI volumes.
+        projection_type: Forwarded to ``MLPProjector``.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int = 4096,
+        clip_name: str = "GoodBaiBai88/M3D-CLIP",
+        trust_remote_code: bool = True,
+        volume_size: Tuple[int, int, int] = (32, 256, 256),
+        proj_out_num: int = 256,
+        num_channels: int = 1,
+        projection_type: str = "mlp",
+        **kwargs,
+    ):
+        super().__init__(
+            modality_type="3d_volume",
+            hidden_size=hidden_size,
+            **kwargs,
+        )
+        self.clip_name = clip_name
+        self.trust_remote_code = trust_remote_code
+        self.volume_size = tuple(volume_size)
+        self.proj_out_num = proj_out_num
+        self.num_channels = num_channels
+        self.projection_type = projection_type
+
+    @property
+    def num_patches(self) -> int:
+        return self.proj_out_num

--- a/src/multimeditron/model/modalities/volume/volume_modality.py
+++ b/src/multimeditron/model/modalities/volume/volume_modality.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import torch
+import torch.nn.functional as F
+from transformers import AutoModel
+
+from multimeditron.model.modalities.base import BaseModality, AutoModality
+from multimeditron.model.modalities.volume.volume_config import VolumeConfig
+from multimeditron.model.modalities.volume.volume_processor import VolumeProcessor
+from multimeditron.model.projectors.mlp import MLPProjector
+
+
+# M3D-CLIP's published patch size. Fixed by the pretrained weights.
+_M3D_CLIP_PATCH_SIZE: Tuple[int, int, int] = (4, 16, 16)
+
+
+def _patch_monai_for_m3dclip() -> None:
+    """Reconcile M3D-CLIP's modeling code with MONAI >= 1.4.
+
+    MONAI 1.4 renamed PatchEmbeddingBlock's ``pos_embed`` kwarg to
+    ``proj_type``; M3D-CLIP's ``modeling_m3d_clip.py`` still passes the
+    old name and crashes with a TypeError at load time.
+
+    See: https://huggingface.co/GoodBaiBai88/M3D-CLIP/discussions/3
+    """
+    try:
+        from monai.networks.blocks.patchembedding import PatchEmbeddingBlock
+    except ImportError:
+        return
+
+    orig = PatchEmbeddingBlock.__init__
+    if getattr(orig, "_m3dclip_patched", False):
+        return
+
+    def patched(self, *args, **kwargs):
+        if "pos_embed" in kwargs and "proj_type" not in kwargs:
+            kwargs["proj_type"] = kwargs.pop("pos_embed")
+        return orig(self, *args, **kwargs)
+
+    patched._m3dclip_patched = True
+    PatchEmbeddingBlock.__init__ = patched
+
+
+def _infer_patch_grid(
+    volume_size: Tuple[int, int, int],
+    patch_size: Tuple[int, int, int] = _M3D_CLIP_PATCH_SIZE,
+) -> Tuple[int, int, int]:
+    return tuple(v // p for v, p in zip(volume_size, patch_size))
+
+
+def _infer_pool_factor(
+    patch_grid: Tuple[int, int, int], proj_out_num: int
+) -> Tuple[int, int, int]:
+    n = patch_grid[0] * patch_grid[1] * patch_grid[2]
+    if n == proj_out_num:
+        return (1, 1, 1)
+    ratio = round((n / proj_out_num) ** (1 / 3))
+    if ratio < 1:
+        ratio = 1
+    return (ratio, ratio, ratio)
+
+
+@AutoModality.register("volume_3d")
+class VolumeModality(BaseModality):
+    """
+    3D Medical Volume Modality backed by a pretrained 3D vision encoder.
+
+    Default backend: M3D-CLIP (``GoodBaiBai88/M3D-CLIP``, Apache-2.0).
+    The encoder produces 1 + (D/4)*(H/16)*(W/16) tokens; the CLS token is
+    dropped, the spatial grid is average-pooled to ``config.proj_out_num``
+    tokens, and the result is projected to ``config.hidden_size`` via the
+    existing ``MLPProjector``.
+
+    Forward:
+        inputs: List of (C, D, H, W) float tensors in [0, 1].
+        returns: (B, proj_out_num, hidden_size).
+    """
+
+    config_class = VolumeConfig
+    preprocessor_class = VolumeProcessor
+
+    def __init__(self, config: VolumeConfig):
+        super().__init__(config)
+
+        _patch_monai_for_m3dclip()
+
+        self.feature_extractor = AutoModel.from_pretrained(
+            config.clip_name,
+            trust_remote_code=config.trust_remote_code,
+        )
+
+        # M3D-CLIP ViT hidden size (768 for the published checkpoint).
+        encoder_config = getattr(self.feature_extractor, "config", None)
+        self.embedding_size = getattr(encoder_config, "hidden_size", 768)
+
+        self._patch_grid = _infer_patch_grid(config.volume_size)
+        self._pool_factor = _infer_pool_factor(self._patch_grid, config.proj_out_num)
+
+        self.projector = MLPProjector(
+            self.embedding_size,
+            config.hidden_size,
+            dtype=self.dtype,
+        )
+
+    def forward(self, inputs: List[torch.Tensor]) -> torch.FloatTensor:
+        x = torch.stack(inputs, dim=0).to(self.device)
+
+        # M3D-CLIP exposes encode_image -> (B, 1 + N_patches, D_vis).
+        tokens = self.feature_extractor.encode_image(x)[:, 1:, :]
+
+        b, n, d = tokens.shape
+        gd, gh, gw = self._patch_grid
+        expected = gd * gh * gw
+        assert n == expected, (
+            f"M3D-CLIP returned {n} patch tokens but config.volume_size "
+            f"implies {gd}x{gh}x{gw}={expected}. Check volume_size."
+        )
+
+        # (B, N, D) -> (B, D, gd, gh, gw) -> avg-pool -> (B, N', D)
+        grid = tokens.transpose(1, 2).reshape(b, d, gd, gh, gw)
+        grid = F.avg_pool3d(grid, kernel_size=self._pool_factor, stride=self._pool_factor)
+        tokens = grid.flatten(2).transpose(1, 2)
+
+        return self.projector(tokens)
+
+    def freeze_modality_embedder(self):
+        for p in self.feature_extractor.parameters():
+            p.requires_grad = False
+
+    def unfreeze_modality_embedder(self):
+        for p in self.feature_extractor.parameters():
+            p.requires_grad = True
+
+    def unfreeze_projection(self):
+        for p in self.projector.parameters():
+            p.requires_grad = True

--- a/src/multimeditron/model/modalities/volume/volume_processor.py
+++ b/src/multimeditron/model/modalities/volume/volume_processor.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from multimeditron.model.modalities.base import BaseModalityProcessor
+from multimeditron.model.modalities.volume.volume_config import VolumeConfig
+from multimeditron.model.constants import MODALITY_VALUE_KEY, NUM_EMBEDDINGS_KEY
+
+
+class VolumeProcessor(BaseModalityProcessor):
+    """
+    Processor for 3D medical volumes (CT, MRI).
+
+    Pipeline:
+        1. ndarray -> float32 tensor
+        2. Trilinear resize to ``config.volume_size`` (D, H, W)
+        3. Per-volume min-max normalize to [0, 1]
+
+    Min-max to [0, 1] matches M3D-CLIP's training distribution. Both
+    M3D-CLIP and DCFormer were pretrained on [0, 1] inputs; skipping this
+    yields out-of-distribution features (the issue is distributional, not
+    floating-point — bf16 has more than enough range for HU values).
+
+    Output: float32 tensor (C, D, H, W) plus
+    ``NUM_EMBEDDINGS_KEY = config.proj_out_num``.
+    """
+
+    def __init__(self, config: VolumeConfig):
+        super().__init__(config)
+        self._num_patches = config.proj_out_num
+
+    def process(self, modality: Dict[str, Any]) -> Dict[str, Any]:
+        processed = modality.copy()
+        volume = modality[MODALITY_VALUE_KEY]
+
+        if isinstance(volume, torch.Tensor):
+            tensor = volume.float()
+        else:
+            tensor = torch.tensor(np.asarray(volume), dtype=torch.float32)
+
+        d, h, w = self.config.volume_size
+        tensor = F.interpolate(
+            tensor.unsqueeze(0),
+            size=(d, h, w),
+            mode="trilinear",
+            align_corners=False,
+        ).squeeze(0)
+
+        vmin = tensor.min()
+        vmax = tensor.max()
+        denom = (vmax - vmin).clamp_min(1e-6)
+        tensor = (tensor - vmin) / denom
+
+        processed[MODALITY_VALUE_KEY] = tensor
+        processed[NUM_EMBEDDINGS_KEY] = self._num_patches
+        return processed

--- a/tests/test_volume_3d.py
+++ b/tests/test_volume_3d.py
@@ -1,0 +1,225 @@
+"""
+Tests for the 3D Volume Modality (Issue #21).
+
+Run with::
+
+    pytest tests/test_volume_3d.py -v
+
+Coverage:
+  * config, loader, processor, registry, freeze/unfreeze — offline,
+    using a synthetic NIfTI generated in ``tmp_path``.
+  * forward pass — mocks ``AutoModel.from_pretrained`` so CI does not
+    download the ~800 MB M3D-CLIP weights.
+  * an optional integration test that hits the real weights, gated by
+    ``RUN_M3DCLIP_WEIGHTS_TESTS=1``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import torch
+
+nib = pytest.importorskip("nibabel")
+
+
+@pytest.fixture
+def synthetic_nifti(tmp_path: Path) -> Path:
+    arr = np.random.rand(64, 64, 32).astype(np.float32)
+    nii = nib.Nifti1Image(arr, np.eye(4))
+    out = tmp_path / "synth.nii.gz"
+    nib.save(nii, str(out))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+def test_volume_config_defaults():
+    from multimeditron.model.modalities.volume.volume_config import VolumeConfig
+
+    cfg = VolumeConfig()
+    assert cfg.modality_type == "3d_volume"
+    assert cfg.hidden_size == 4096
+    assert cfg.clip_name == "GoodBaiBai88/M3D-CLIP"
+    assert cfg.trust_remote_code is True
+    assert cfg.volume_size == (32, 256, 256)
+    assert cfg.proj_out_num == 256
+    assert cfg.num_channels == 1
+    assert cfg.num_patches == 256
+
+
+def test_volume_config_custom():
+    from multimeditron.model.modalities.volume.volume_config import VolumeConfig
+
+    cfg = VolumeConfig(volume_size=(64, 128, 128), proj_out_num=64)
+    assert cfg.volume_size == (64, 128, 128)
+    assert cfg.proj_out_num == 64
+    assert cfg.num_patches == 64
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+def test_volume_loader(synthetic_nifti: Path):
+    from multimeditron.dataset.loader.volume.volume_loader import (
+        FileSystemVolumeLoader,
+    )
+
+    loader = FileSystemVolumeLoader(base_path=str(synthetic_nifti.parent))
+    sample = {"value": synthetic_nifti.name, "type": "3d_volume"}
+    vol = loader.load(sample)
+
+    assert isinstance(vol, np.ndarray)
+    assert vol.dtype == np.float32
+    assert vol.ndim == 4
+    assert vol.shape[0] == 1
+
+
+def test_volume_loader_missing_file(tmp_path: Path):
+    from multimeditron.dataset.loader.volume.volume_loader import (
+        FileSystemVolumeLoader,
+    )
+
+    loader = FileSystemVolumeLoader(base_path=str(tmp_path))
+    with pytest.raises(FileNotFoundError):
+        loader.load({"value": "does_not_exist.nii.gz", "type": "3d_volume"})
+
+
+# ---------------------------------------------------------------------------
+# Processor
+# ---------------------------------------------------------------------------
+
+def test_volume_processor(synthetic_nifti: Path):
+    from multimeditron.model.constants import (
+        MODALITY_VALUE_KEY,
+        NUM_EMBEDDINGS_KEY,
+    )
+    from multimeditron.model.modalities.volume.volume_config import VolumeConfig
+    from multimeditron.model.modalities.volume.volume_processor import (
+        VolumeProcessor,
+    )
+
+    cfg = VolumeConfig()
+    proc = VolumeProcessor(cfg)
+
+    arr = nib.load(str(synthetic_nifti)).get_fdata().astype(np.float32)[None]
+    out = proc.process({MODALITY_VALUE_KEY: arr, "type": "3d_volume"})
+    tensor = out[MODALITY_VALUE_KEY]
+
+    assert isinstance(tensor, torch.Tensor)
+    assert tensor.shape == (cfg.num_channels, *cfg.volume_size)
+    assert tensor.dtype == torch.float32
+    assert tensor.min().item() >= 0.0
+    assert tensor.max().item() <= 1.0
+    assert out[NUM_EMBEDDINGS_KEY] == cfg.proj_out_num
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+def test_registry():
+    from multimeditron.dataset.loader import AutoModalityLoader
+    from multimeditron.model.modalities.base import AutoModality
+
+    assert "volume_3d" in AutoModality._registry
+    assert "fs-volume" in AutoModalityLoader._registry
+
+
+# ---------------------------------------------------------------------------
+# Mocked-encoder forward / freeze tests
+# ---------------------------------------------------------------------------
+
+class _StubEncoder(torch.nn.Module):
+    """Mimics M3D-CLIP's ``encode_image`` contract without real weights."""
+
+    def __init__(self, hidden_size: int = 768, n_patches: int = 2048):
+        super().__init__()
+        self._hidden_size = hidden_size
+        self._n_patches = n_patches
+        self.config = MagicMock(hidden_size=hidden_size)
+        self.dummy = torch.nn.Parameter(torch.zeros(1))
+
+    def encode_image(self, x: torch.Tensor) -> torch.Tensor:
+        b = x.shape[0]
+        return torch.zeros(
+            b, 1 + self._n_patches, self._hidden_size, dtype=x.dtype
+        )
+
+
+def _build_modality_with_stub():
+    from multimeditron.model.modalities.volume import volume_modality as vm
+    from multimeditron.model.modalities.volume.volume_config import VolumeConfig
+
+    stub = _StubEncoder()
+    with patch.object(vm, "AutoModel") as mock_auto:
+        mock_auto.from_pretrained.return_value = stub
+        cfg = VolumeConfig()
+        mod = vm.VolumeModality(cfg)
+    return cfg, mod, stub
+
+
+def test_modality_forward_mocked():
+    cfg, mod, _ = _build_modality_with_stub()
+    mod.eval()
+
+    x = torch.randn(2, cfg.num_channels, *cfg.volume_size)
+    with torch.no_grad():
+        out = mod([x[i] for i in range(2)])
+
+    assert out.shape == (2, cfg.proj_out_num, cfg.hidden_size)
+
+
+def test_freeze_unfreeze_mocked():
+    _, mod, _ = _build_modality_with_stub()
+
+    mod.freeze_modality_embedder()
+    assert all(not p.requires_grad for p in mod.feature_extractor.parameters())
+
+    mod.unfreeze_modality_embedder()
+    assert all(p.requires_grad for p in mod.feature_extractor.parameters())
+
+    mod.unfreeze_projection()
+    assert all(p.requires_grad for p in mod.projector.parameters())
+
+
+# ---------------------------------------------------------------------------
+# Optional integration test — pulls real M3D-CLIP weights (~800 MB).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    os.environ.get("RUN_M3DCLIP_WEIGHTS_TESTS") != "1",
+    reason="Set RUN_M3DCLIP_WEIGHTS_TESTS=1 to enable (downloads ~800 MB).",
+)
+def test_modality_forward_real_weights(synthetic_nifti: Path):
+    from multimeditron.dataset.loader.volume.volume_loader import (
+        FileSystemVolumeLoader,
+    )
+    from multimeditron.model.constants import MODALITY_VALUE_KEY
+    from multimeditron.model.modalities.volume.volume_config import VolumeConfig
+    from multimeditron.model.modalities.volume.volume_modality import (
+        VolumeModality,
+    )
+    from multimeditron.model.modalities.volume.volume_processor import (
+        VolumeProcessor,
+    )
+
+    cfg = VolumeConfig()
+    loader = FileSystemVolumeLoader(base_path=str(synthetic_nifti.parent))
+    proc = VolumeProcessor(cfg)
+    mod = VolumeModality(cfg).eval()
+
+    raw = loader.load({"value": synthetic_nifti.name, "type": "3d_volume"})
+    out = proc.process({MODALITY_VALUE_KEY: raw, "type": "3d_volume"})
+
+    with torch.no_grad():
+        result = mod([out[MODALITY_VALUE_KEY]])
+
+    assert result.shape == (1, cfg.proj_out_num, cfg.hidden_size)


### PR DESCRIPTION
Implements native 3D medical volume (MRI/CT NIfTI) support as a first-class modality
Follows the existing `AutoModality` / `AutoModalityLoader` registration pattern

## Architecture 

```text
NIfTI file (.nii/.nii.gz)                                                                           
  → FileSystemVolumeLoader       # nibabel, returns (C, D, H, W)
  → VolumeProcessor              # trilinear resize → per-volume normalize → ±3σ clip                         
  → VolumeModality (3D ViT)                                                                                    
      ├── Conv3d patch embed     # (C, 96, 96, 96) → (768, 6, 6, 6)                                         
      ├── Flatten + pos embed    # (B, 216, 768)   ← 216 = (96/16)³                                           
      ├── TransformerEncoder     # 12-layer, pre-norm, GELU, d_model = 768                          
      └── MLPProjector           # (B, 216, 4096)  → LLM sequence   
```
<img width="573" height="711" alt="Screenshot 2026-04-05 at 8 00 31 PM" src="https://github.com/user-attachments/assets/15c934c0-b985-47a2-b252-3ad83271678c" style="display: block; margin: auto;" />

  ## New Files

  | File | Purpose |
  |---|---|
  | `dataset/loader/volume/volume_loader.py` | `FileSystemVolumeLoader`, registered as `fs-volume` |
  | `model/modalities/volume/volume_config.py` | `VolumeConfig` — patch/volume/encoder params, validates divisibility |
  | `model/modalities/volume/volume_processor.py` | `VolumeProcessor` — resize, normalize, clip |
  | `model/modalities/volume/volume_modality.py` | `VolumeModality`, registered as `volume_3d` |
  | `cookbook/sft/volume_3d/llama_volume/stage1_alignment.yaml` | ALIGNMENT training config |
  | `cookbook/sft/volume_3d/llama_volume/stage2_end2end.yaml` | END2END training config |
  | `notebooks/demo_3d_volume_modality.ipynb` | End-to-end demo notebook (outputs included) |

  ## Modified Files

  | File | Change |
  |---|---|
  | `dataset/loader/__init__.py` | Added `FileSystemVolumeLoader` import |
  | `model/modalities/__init__.py` | Added `VolumeConfig`, `VolumeModality`, `VolumeProcessor` imports |
  | `pyproject.toml` | Added `nibabel` dependency |

Closes #21