### PR TITLE
Add 3D volume modality

### DIFF
--- a/cookbook/sft/volume_3d/llama_volume/stage1_alignment.yaml
+++ b/cookbook/sft/volume_3d/llama_volume/stage1_alignment.yaml
@@ -1,0 +1,54 @@
+base_llm: meta-llama/Llama-3.1-8B-Instruct
+base_model: null
+resume_from_checkpoint: false
+wandb_run_id: null
+attachment_token: <|reserved_special_token_0|>
+tokenizer_type: llama
+token_size: 4096
+
+loaders:
+  - loader_type: fs-volume
+    modality_type: image_3d
+    base_path: $STORAGE_ROOT/volume_3d/images
+
+modalities:
+  - model_type: volume_3d
+    pretrain_vision_model: GoodBaiBai88/M3D-CLIP
+    trust_remote_code: true
+    hidden_size: 4096
+    volume_size: [32, 256, 256]
+    proj_out_num: 256
+
+training_mode: ALIGNMENT
+
+datasets:
+  # Dataset samples should contain modalities like:
+  # {"type": "image_3d", "value": "relative/path/to/volume.npy"}
+  - packed_path: $STORAGE_ROOT/volume_3d/alignment
+
+training_args:
+  output_dir: $MODEL_ROOT/freeze/volume_3d/MultiMeditron-Llama-8B-Alignment-Volume3D/
+  dataloader_num_workers: 8
+  dataloader_prefetch_factor: 2
+  remove_unused_columns: false
+  ddp_find_unused_parameters: false
+  learning_rate: 1.0e-4
+  bf16: true
+  per_device_train_batch_size: 1
+  gradient_accumulation_steps: 16
+  num_train_epochs: 1
+  gradient_checkpointing: true
+  gradient_checkpointing_kwargs:
+    use_reentrant: true
+  save_strategy: epoch
+  max_grad_norm: 1.0
+  run_name: MultiMeditron-Llama-8B-Volume3D-Alignment
+  deepspeed: $WORKING_DIR/config/deepspeed.json
+  accelerator_config:
+    dispatch_batches: false
+  lr_scheduler_type: "cosine_with_min_lr"
+  lr_scheduler_kwargs:
+    min_lr: 3.0e-5
+  report_to: wandb
+  logging_steps: 1
+  weight_decay: 0.01

--- a/src/multimeditron/cli/check_dataset.py
+++ b/src/multimeditron/cli/check_dataset.py
@@ -176,8 +176,14 @@ def _validate_row(sample: Dict[str, Any], modality_type: str, attachment_token: 
 
 @main_cli.command(epilog=EPILOG)
 @click.argument("dataset_path", type=click.Path(exists=True, file_okay=True, dir_okay=True))
-@click.option("--modality", "-m", "modality_type", type=click.Choice(["image"], case_sensitive=False),
-              required=True, help="Modality type to validate (currently only 'image').")
+@click.option(
+    "--modality",
+    "-m",
+    "modality_type",
+    type=click.Choice(["image", "image_3d"], case_sensitive=False),
+    required=True,
+    help="Modality type to validate (supported: image, image_3d).",
+)
 @click.option("--attachment-token", default=DEFAULT_ATTACHMENT_TOKEN, show_default=True,
               help="Token used in text/conversations to indicate modality placement.")
 @click.option("--max-samples", type=int, default=None,
@@ -186,8 +192,12 @@ def _validate_row(sample: Dict[str, Any], modality_type: str, attachment_token: 
               help="Number of processes to use for validation (default: CPU count).")
 @click.option("--verify-load/--no-verify-load", default=False,
               help="Attempt to load modalities using the specified loader to detect corrupt inputs.")
-@click.option("--loader-type", type=str, default=None,
-              help="Loader type to use for validation (e.g. raw-image, fs-image).")
+@click.option(
+    "--loader-type",
+    type=str,
+    default=None,
+    help="Loader type to use for validation (e.g. raw-image/fs-image for image, raw-volume/fs-volume for image_3d).",
+)
 @click.option("--loader-kwargs", type=str, default=None,
               help="JSON string of kwargs to pass to the loader (e.g. '{\"base_path\": \"/data\"}').")
 def check_dataset(dataset_path: str, modality_type: str, attachment_token: str,

--- a/src/multimeditron/dataset/loader/__init__.py
+++ b/src/multimeditron/dataset/loader/__init__.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List
 from multimeditron.model.constants import MODALITIES_KEY, MODALITY_TYPE_KEY, MODALITY_VALUE_KEY
-from multimeditron.dataset.loader.volume.volume_loader import FileSystemVolumeLoader, RawVolumeLoader
 
 
 
@@ -158,6 +157,7 @@ class AutoModalityLoader:
 
 from multimeditron.dataset.loader.image.bytes import RawImageLoader
 from multimeditron.dataset.loader.image.fs import FileSystemImageLoader
+from multimeditron.dataset.loader.volume.volume_loader import FileSystemVolumeLoader, RawVolumeLoader
 
 __all__ = [
     "BaseModalityLoader",

--- a/src/multimeditron/dataset/loader/__init__.py
+++ b/src/multimeditron/dataset/loader/__init__.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List
 from multimeditron.model.constants import MODALITIES_KEY, MODALITY_TYPE_KEY, MODALITY_VALUE_KEY
+from multimeditron.dataset.loader.volume.volume_loader import FileSystemVolumeLoader, RawVolumeLoader
+
 
 
 class BaseModalityLoader(ABC):
@@ -162,5 +164,7 @@ __all__ = [
     "AutoModalityLoader",
     "RawImageLoader",
     "FileSystemImageLoader",
+    "FileSystemVolumeLoader",
+    "RawVolumeLoader",
 ]
 

--- a/src/multimeditron/dataset/loader/volume/volume_loader.py
+++ b/src/multimeditron/dataset/loader/volume/volume_loader.py
@@ -1,0 +1,81 @@
+import io
+import os
+import pathlib
+from typing import Any, Dict, Union
+
+import numpy as np
+
+from multimeditron.dataset.loader import AutoModalityLoader, BaseModalityLoader
+from multimeditron.model.constants import MODALITY_VALUE_KEY
+
+
+def _load_npy_from_path(path: str) -> np.ndarray:
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Volume file {path} not found")
+    if not path.lower().endswith(".npy"):
+        raise ValueError(f"Expected a .npy volume file, got: {path}")
+
+    arr = np.load(path, allow_pickle=False)
+    if not isinstance(arr, np.ndarray):
+        raise ValueError(f"Loaded object from {path} is not a numpy array")
+    return arr
+
+
+def _load_npy_from_bytes(raw_bytes: bytes) -> np.ndarray:
+    arr = np.load(io.BytesIO(raw_bytes), allow_pickle=False)
+    if not isinstance(arr, np.ndarray):
+        raise ValueError("Loaded object from raw bytes is not a numpy array")
+    return arr
+
+
+@AutoModalityLoader.register("fs-volume")
+class FileSystemVolumeLoader(BaseModalityLoader):
+    """
+    Loader for volume files from the filesystem.
+    Expects sample["value"] to be a relative path under base_path.
+    Only .npy files are supported.
+    """
+
+    def __init__(self, base_path: Union[str, pathlib.Path]):
+        super().__init__()
+        self.base_path = base_path
+
+    def load(self, sample: Dict[str, Any]) -> np.ndarray:
+        value = sample.get(MODALITY_VALUE_KEY)
+        if not isinstance(value, str):
+            raise ValueError(
+                f"Expected '{MODALITY_VALUE_KEY}' to be a relative path string for fs-volume"
+            )
+        volume_path = os.path.join(self.base_path, value)
+        return _load_npy_from_path(volume_path)
+
+
+@AutoModalityLoader.register("raw-volume")
+class RawVolumeLoader(BaseModalityLoader):
+    """
+    Loader for in-memory/raw volumes.
+    Supports either:
+      - numpy.ndarray directly, or
+      - dict-like Arrow payload with {"bytes": <raw .npy bytes>}.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def load(self, sample: Dict[str, Any]) -> np.ndarray:
+        value = sample.get(MODALITY_VALUE_KEY)
+
+        if isinstance(value, np.ndarray):
+            return value
+
+        if isinstance(value, dict) and "bytes" in value:
+            raw_bytes = value["bytes"]
+            if not isinstance(raw_bytes, (bytes, bytearray)):
+                raise ValueError(
+                    "Expected raw-volume bytes payload to be 'bytes' or 'bytearray'"
+                )
+            return _load_npy_from_bytes(bytes(raw_bytes))
+
+        raise ValueError(
+            "Unsupported raw-volume value. Expected numpy.ndarray or {'bytes': ...} payload."
+        )

--- a/src/multimeditron/model/modalities/__init__.py
+++ b/src/multimeditron/model/modalities/__init__.py
@@ -3,6 +3,9 @@ from multimeditron.model.modalities.image_modality_moe import MOEImageConfig, MO
 from multimeditron.model.modalities.image_modality_moe_pep import MOEImageConfigPEP, MOEImageModalityPEP, MOEImageProcessorPEP
 from multimeditron.model.modalities.image_modality import ImageConfig, ImageModality, ImageProcessor
 from multimeditron.model.modalities.image_modality_biomed import BioMedCLIPImageConfig, BioMedCLIPImageModality, BioMedCLIPImageProcessor
+from multimeditron.model.modalities.volume.volume_config import VolumeConfig
+from multimeditron.model.modalities.volume.volume_processor import VolumeProcessor
+from multimeditron.model.modalities.volume.volume_modality import VolumeModality
 
 __all__ = [
     "BaseModality",
@@ -21,4 +24,7 @@ __all__ = [
     "BioMedCLIPImageConfig",
     "BioMedCLIPImageModality",
     "BioMedCLIPImageProcessor",
+    "VolumeConfig",
+    "VolumeProcessor",
+    "VolumeModality",
 ]

--- a/src/multimeditron/model/modalities/volume/__init__.py
+++ b/src/multimeditron/model/modalities/volume/__init__.py
@@ -1,0 +1,5 @@
+from multimeditron.model.modalities.volume.volume_config import VolumeConfig
+from multimeditron.model.modalities.volume.volume_processor import VolumeProcessor
+from multimeditron.model.modalities.volume.volume_modality import VolumeModality
+
+__all__ = ["VolumeConfig", "VolumeProcessor", "VolumeModality"]

--- a/src/multimeditron/model/modalities/volume/volume_config.py
+++ b/src/multimeditron/model/modalities/volume/volume_config.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+from multimeditron.model.modalities.base import BaseModalityConfig
+
+
+class VolumeConfig(BaseModalityConfig):
+    """
+    Configuration for the 3D volume modality.
+
+    This config is used by:
+    - VolumeProcessor (shape resize/normalization contract)
+    - VolumeModality (vision encoder + projector settings)
+    """
+
+    def __init__(
+        self,
+        hidden_size: int = 4096,
+        pretrain_vision_model: str | None = None,
+        trust_remote_code: bool = True,
+        projection_type: str = "mlp",
+        volume_size: Tuple[int, int, int] = (32, 256, 256),
+        proj_out_num: int = 256,
+        pool_factor: Tuple[int, int, int] | None = None,
+        clip_revision: str | None = None,
+        **kwargs,
+    ):
+        super().__init__(
+            modality_type="image_3d",
+            hidden_size=hidden_size,
+            **kwargs,
+        )
+
+        self.pretrain_vision_model = pretrain_vision_model
+        self.trust_remote_code = trust_remote_code
+        self.projection_type = projection_type
+        self.volume_size = tuple(int(x) for x in volume_size)
+        self.proj_out_num = int(proj_out_num)
+        self.pool_factor = tuple(int(x) for x in pool_factor) if pool_factor is not None else None
+        self.clip_revision = clip_revision
+
+        self._validate()
+
+    def _validate(self) -> None:
+        if not self.pretrain_vision_model:
+            raise ValueError("A pretrained 3D vision model must be provided via 'pretrain_vision_model'.")
+        if len(self.volume_size) != 3:
+            raise ValueError(
+                f"volume_size must be (D, H, W), got: {self.volume_size}"
+            )
+        if any(v <= 0 for v in self.volume_size):
+            raise ValueError(
+                f"volume_size values must be > 0, got: {self.volume_size}"
+            )
+        if self.proj_out_num <= 0:
+            raise ValueError(f"proj_out_num must be > 0, got: {self.proj_out_num}")
+
+        if self.pool_factor is not None:
+            if len(self.pool_factor) != 3:
+                raise ValueError(
+                    f"pool_factor must be (fd, fh, fw), got: {self.pool_factor}"
+                )
+            if any(p <= 0 for p in self.pool_factor):
+                raise ValueError(
+                    f"pool_factor values must be > 0, got: {self.pool_factor}"
+                )

--- a/src/multimeditron/model/modalities/volume/volume_config.py
+++ b/src/multimeditron/model/modalities/volume/volume_config.py
@@ -32,6 +32,7 @@ class VolumeConfig(BaseModalityConfig):
         clip_revision: str | None = None,
         **kwargs,
     ):
+        kwargs.pop("modality_type", None)
         super().__init__(
             modality_type="image_3d",
             hidden_size=hidden_size,
@@ -55,6 +56,11 @@ class VolumeConfig(BaseModalityConfig):
     def _validate(self) -> None:
         if not self.pretrain_vision_model:
             raise ValueError("A pretrained 3D vision model must be provided via 'pretrain_vision_model'.")
+        if self.projection_type != "mlp":
+            raise ValueError(
+                "VolumeConfig currently supports only projection_type=mlp, "
+                f"got: {self.projection_type}"
+            )
         if len(self.volume_size) != 3:
             raise ValueError(
                 f"volume_size must be (D, H, W), got: {self.volume_size}"

--- a/src/multimeditron/model/modalities/volume/volume_config.py
+++ b/src/multimeditron/model/modalities/volume/volume_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from math import prod
 from typing import Tuple
 
 from multimeditron.model.modalities.base import BaseModalityConfig
@@ -25,8 +26,9 @@ class VolumeConfig(BaseModalityConfig):
         trust_remote_code: bool = True,
         projection_type: str = "mlp",
         volume_size: Tuple[int, int, int] = (32, 256, 256),
+        patch_size: Tuple[int, int, int] = (4, 16, 16),
         proj_out_num: int = 256,
-        pool_factor: Tuple[int, int, int] | None = None,
+        pool_factor: Tuple[int, int, int] = (2, 2, 2),
         clip_revision: str | None = None,
         **kwargs,
     ):
@@ -40,9 +42,13 @@ class VolumeConfig(BaseModalityConfig):
         self.trust_remote_code = trust_remote_code
         self.projection_type = projection_type
         self.volume_size = tuple(int(x) for x in volume_size)
+        self.patch_size = tuple(int(x) for x in patch_size)
         self.proj_out_num = int(proj_out_num)
-        self.pool_factor = tuple(int(x) for x in pool_factor) if pool_factor is not None else None
+        self.pool_factor = tuple(int(x) for x in pool_factor)
         self.clip_revision = clip_revision
+
+        self.num_patches_pre: Tuple[int, int, int]
+        self.num_patches_post: Tuple[int, int, int]
 
         self._validate()
 
@@ -60,12 +66,45 @@ class VolumeConfig(BaseModalityConfig):
         if self.proj_out_num <= 0:
             raise ValueError(f"proj_out_num must be > 0, got: {self.proj_out_num}")
 
-        if self.pool_factor is not None:
-            if len(self.pool_factor) != 3:
-                raise ValueError(
-                    f"pool_factor must be (fd, fh, fw), got: {self.pool_factor}"
-                )
-            if any(p <= 0 for p in self.pool_factor):
-                raise ValueError(
-                    f"pool_factor values must be > 0, got: {self.pool_factor}"
-                )
+        if len(self.patch_size) != 3:
+            raise ValueError(f"patch_size must be (d, h, w), got: {self.patch_size}")
+        if any(p <= 0 for p in self.patch_size):
+            raise ValueError(
+                f"patch_size values must be > 0, got: {self.patch_size}"
+            )
+
+        if len(self.pool_factor) != 3:
+            raise ValueError(
+                f"pool_factor must be (fd, fh, fw), got: {self.pool_factor}"
+            )
+        if any(p <= 0 for p in self.pool_factor):
+            raise ValueError(
+                f"pool_factor values must be > 0, got: {self.pool_factor}"
+            )
+
+        if any(v % pch != 0 for v, pch in zip(self.volume_size, self.patch_size)):
+            raise ValueError(
+                "volume_size must be divisible by patch_size per axis, "
+                f"got volume_size={self.volume_size}, patch_size={self.patch_size}"
+            )
+        self.num_patches_pre = tuple(
+            v // pch for v, pch in zip(self.volume_size, self.patch_size)
+        )
+
+        if any(n % f != 0 for n, f in zip(self.num_patches_pre, self.pool_factor)):
+            raise ValueError(
+                "num_patches_pre must be divisible by pool_factor per axis, "
+                f"got num_patches_pre={self.num_patches_pre}, pool_factor={self.pool_factor}"
+            )
+        self.num_patches_post = tuple(
+            n // f for n, f in zip(self.num_patches_pre, self.pool_factor)
+        )
+
+        expected_proj_out_num = prod(self.num_patches_post)
+        if self.proj_out_num != expected_proj_out_num:
+            raise ValueError(
+                "proj_out_num must match derived post-pooling token count, "
+                f"expected {expected_proj_out_num} from volume_size={self.volume_size}, "
+                f"patch_size={self.patch_size}, pool_factor={self.pool_factor}, "
+                f"got proj_out_num={self.proj_out_num}"
+            )

--- a/src/multimeditron/model/modalities/volume/volume_config.py
+++ b/src/multimeditron/model/modalities/volume/volume_config.py
@@ -12,12 +12,16 @@ class VolumeConfig(BaseModalityConfig):
     This config is used by:
     - VolumeProcessor (shape resize/normalization contract)
     - VolumeModality (vision encoder + projector settings)
+
+    pretrain_vision_model accepts either:
+    - a Hugging Face model id (e.g. GoodBaiBai88/M3D-CLIP), or
+    - a local model path.
     """
 
     def __init__(
         self,
         hidden_size: int = 4096,
-        pretrain_vision_model: str | None = None,
+        pretrain_vision_model: str = "GoodBaiBai88/M3D-CLIP",
         trust_remote_code: bool = True,
         projection_type: str = "mlp",
         volume_size: Tuple[int, int, int] = (32, 256, 256),

--- a/src/multimeditron/model/modalities/volume/volume_modality.py
+++ b/src/multimeditron/model/modalities/volume/volume_modality.py
@@ -38,6 +38,7 @@ class VolumeModality(BaseModality):
         )
 
         remote_cfg = getattr(self.feature_extractor, "config", None)
+        self._validate_remote_config(remote_cfg, config)
         self.embedding_size = int(getattr(remote_cfg, "hidden_size", 768))
         self.projector = MLPProjector(
             self.embedding_size,
@@ -49,14 +50,58 @@ class VolumeModality(BaseModality):
 
         self._embedder_frozen = False
 
+    @staticmethod
+    def _as_tuple(value):
+        if value is None:
+            return None
+        return tuple(int(x) for x in value)
+
+    def _validate_remote_config(self, remote_cfg, config: VolumeConfig) -> None:
+        if remote_cfg is None:
+            return
+
+        remote_img_size = self._as_tuple(getattr(remote_cfg, "img_size", None))
+        if remote_img_size is not None and remote_img_size != config.volume_size:
+            raise ValueError(
+                "Loaded 3D encoder img_size does not match VolumeConfig.volume_size: "
+                f"{remote_img_size} != {config.volume_size}"
+            )
+
+        remote_patch_size = self._as_tuple(getattr(remote_cfg, "patch_size", None))
+        if remote_patch_size is not None and remote_patch_size != config.patch_size:
+            raise ValueError(
+                "Loaded 3D encoder patch_size does not match VolumeConfig.patch_size: "
+                f"{remote_patch_size} != {config.patch_size}"
+            )
+
+        remote_in_channels = getattr(remote_cfg, "in_channels", None)
+        if remote_in_channels is not None and int(remote_in_channels) != 1:
+            raise ValueError(
+                "This volume_3d implementation currently supports only single-channel "
+                f"M3D-CLIP inputs; loaded encoder has in_channels={remote_in_channels}"
+            )
+
+    @staticmethod
+    def _first_tensor(output):
+        if isinstance(output, torch.Tensor):
+            return output
+        if hasattr(output, "last_hidden_state"):
+            return output.last_hidden_state
+        if isinstance(output, (tuple, list)) and len(output) > 0:
+            return VolumeModality._first_tensor(output[0])
+        raise ValueError(f"Could not extract token tensor from encoder output type {type(output)}")
+
     def _encode_tokens(self, x: torch.Tensor) -> torch.Tensor:
-        if hasattr(self.feature_extractor, "encode_image"):
-            tokens = self.feature_extractor.encode_image(x)
+        if hasattr(self.feature_extractor, "vision_encoder"):
+            tokens = self._first_tensor(self.feature_extractor.vision_encoder(x))
         elif hasattr(self.feature_extractor, "vision_model"):
-            tokens = self.feature_extractor.vision_model(x).last_hidden_state
+            tokens = self._first_tensor(self.feature_extractor.vision_model(x))
+        elif hasattr(self.feature_extractor, "encode_image"):
+            # Fallback for encoders that expose only projected CLIP features.
+            tokens = self.feature_extractor.encode_image(x)
         else:
             raise ValueError(
-                "Volume encoder must implement `encode_image` or `vision_model(...).last_hidden_state`."
+                "Volume encoder must implement `vision_encoder`, `vision_model`, or `encode_image`."
             )
 
         if tokens.ndim != 3:
@@ -110,7 +155,8 @@ class VolumeModality(BaseModality):
         return pooled_tokens
 
     def forward(self, inputs: List[torch.Tensor]) -> torch.FloatTensor:
-        x = torch.stack(inputs, dim=0).to(self.device)
+        target_dtype = next(self.feature_extractor.parameters()).dtype
+        x = torch.stack(inputs, dim=0).to(device=self.device, dtype=target_dtype)
         tokens = self._encode_tokens(x)
         tokens = self._spatial_pool_tokens(tokens)
         return self.projector(tokens)

--- a/src/multimeditron/model/modalities/volume/volume_modality.py
+++ b/src/multimeditron/model/modalities/volume/volume_modality.py
@@ -44,6 +44,8 @@ class VolumeModality(BaseModality):
             config.hidden_size,
             dtype=self.dtype,
         )
+        self._patch_grid_pre = config.num_patches_pre
+        self._patch_grid_post = config.num_patches_post
 
         self._embedder_frozen = False
 
@@ -60,23 +62,57 @@ class VolumeModality(BaseModality):
         if tokens.ndim != 3:
             raise ValueError(f"Expected token tensor of shape (B, N, D), got {tuple(tokens.shape)}")
 
-        # M3D-CLIP style outputs include a CLS token. Remove it when possible.
-        if tokens.shape[1] > self.config.proj_out_num:
+        expected_pre_tokens = (
+            self._patch_grid_pre[0] * self._patch_grid_pre[1] * self._patch_grid_pre[2]
+        )
+        if tokens.shape[1] == expected_pre_tokens + 1:
             tokens = tokens[:, 1:, :]
+        elif tokens.shape[1] != expected_pre_tokens:
+            raise ValueError(
+                "Unexpected number of encoder tokens. "
+                f"Expected {expected_pre_tokens} (or {expected_pre_tokens + 1} with CLS), "
+                f"got {tokens.shape[1]}"
+            )
         return tokens
 
-    def _pool_tokens(self, tokens: torch.Tensor) -> torch.Tensor:
-        target_tokens = int(self.config.proj_out_num)
-        if tokens.shape[1] == target_tokens:
-            return tokens
+    def _spatial_pool_tokens(self, tokens: torch.Tensor) -> torch.Tensor:
+        batch_size, token_count, embed_dim = tokens.shape
+        grid_d, grid_h, grid_w = self._patch_grid_pre
+        expected_pre_tokens = grid_d * grid_h * grid_w
+        if token_count != expected_pre_tokens:
+            raise ValueError(
+                "Token count does not match pre-pooling grid. "
+                f"Expected {expected_pre_tokens}, got {token_count}"
+            )
 
-        pooled = F.adaptive_avg_pool1d(tokens.transpose(1, 2), target_tokens)
-        return pooled.transpose(1, 2)
+        x = tokens.transpose(1, 2).reshape(batch_size, embed_dim, grid_d, grid_h, grid_w)
+        pool_d, pool_h, pool_w = self.config.pool_factor
+        x = F.avg_pool3d(
+            x,
+            kernel_size=(pool_d, pool_h, pool_w),
+            stride=(pool_d, pool_h, pool_w),
+        )
+        pooled_tokens = x.flatten(2).transpose(1, 2)
+
+        expected_post_tokens = (
+            self._patch_grid_post[0] * self._patch_grid_post[1] * self._patch_grid_post[2]
+        )
+        if pooled_tokens.shape[1] != expected_post_tokens:
+            raise ValueError(
+                "Unexpected post-pooling token count. "
+                f"Expected {expected_post_tokens}, got {pooled_tokens.shape[1]}"
+            )
+        if pooled_tokens.shape[1] != self.config.proj_out_num:
+            raise ValueError(
+                "Post-pooling token count does not match proj_out_num. "
+                f"Expected {self.config.proj_out_num}, got {pooled_tokens.shape[1]}"
+            )
+        return pooled_tokens
 
     def forward(self, inputs: List[torch.Tensor]) -> torch.FloatTensor:
         x = torch.stack(inputs, dim=0).to(self.device)
         tokens = self._encode_tokens(x)
-        tokens = self._pool_tokens(tokens)
+        tokens = self._spatial_pool_tokens(tokens)
         return self.projector(tokens)
 
     def freeze_modality_embedder(self):

--- a/src/multimeditron/model/modalities/volume/volume_modality.py
+++ b/src/multimeditron/model/modalities/volume/volume_modality.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from typing import List
+
+import torch
+import torch.nn.functional as F
+from transformers import AutoModel
+
+from multimeditron.model.modalities.base import AutoModality, BaseModality
+from multimeditron.model.modalities.volume.volume_config import VolumeConfig
+from multimeditron.model.modalities.volume.volume_processor import VolumeProcessor
+from multimeditron.model.projectors.mlp import MLPProjector
+
+
+@AutoModality.register("volume_3d")
+class VolumeModality(BaseModality):
+    """
+    3D volume modality backed by a pretrained vision encoder.
+
+    Expected encoder behavior:
+    - expose `encode_image(x)` that returns token features, or
+    - expose `vision_model(x).last_hidden_state`.
+    """
+
+    config_class = VolumeConfig
+    preprocessor_class = VolumeProcessor
+
+    def __init__(self, config: VolumeConfig):
+        super().__init__(config)
+
+        load_kwargs = {"trust_remote_code": config.trust_remote_code}
+        if config.clip_revision is not None:
+            load_kwargs["revision"] = config.clip_revision
+
+        self.feature_extractor = AutoModel.from_pretrained(
+            config.pretrain_vision_model,
+            **load_kwargs,
+        )
+
+        remote_cfg = getattr(self.feature_extractor, "config", None)
+        self.embedding_size = int(getattr(remote_cfg, "hidden_size", 768))
+        self.projector = MLPProjector(
+            self.embedding_size,
+            config.hidden_size,
+            dtype=self.dtype,
+        )
+
+        self._embedder_frozen = False
+
+    def _encode_tokens(self, x: torch.Tensor) -> torch.Tensor:
+        if hasattr(self.feature_extractor, "encode_image"):
+            tokens = self.feature_extractor.encode_image(x)
+        elif hasattr(self.feature_extractor, "vision_model"):
+            tokens = self.feature_extractor.vision_model(x).last_hidden_state
+        else:
+            raise ValueError(
+                "Volume encoder must implement `encode_image` or `vision_model(...).last_hidden_state`."
+            )
+
+        if tokens.ndim != 3:
+            raise ValueError(f"Expected token tensor of shape (B, N, D), got {tuple(tokens.shape)}")
+
+        # M3D-CLIP style outputs include a CLS token. Remove it when possible.
+        if tokens.shape[1] > self.config.proj_out_num:
+            tokens = tokens[:, 1:, :]
+        return tokens
+
+    def _pool_tokens(self, tokens: torch.Tensor) -> torch.Tensor:
+        target_tokens = int(self.config.proj_out_num)
+        if tokens.shape[1] == target_tokens:
+            return tokens
+
+        pooled = F.adaptive_avg_pool1d(tokens.transpose(1, 2), target_tokens)
+        return pooled.transpose(1, 2)
+
+    def forward(self, inputs: List[torch.Tensor]) -> torch.FloatTensor:
+        x = torch.stack(inputs, dim=0).to(self.device)
+        tokens = self._encode_tokens(x)
+        tokens = self._pool_tokens(tokens)
+        return self.projector(tokens)
+
+    def freeze_modality_embedder(self):
+        for p in self.feature_extractor.parameters():
+            p.requires_grad = False
+        self.feature_extractor.eval()
+        self._embedder_frozen = True
+
+    def unfreeze_modality_embedder(self):
+        for p in self.feature_extractor.parameters():
+            p.requires_grad = True
+        self._embedder_frozen = False
+
+    def unfreeze_projection(self):
+        for p in self.projector.parameters():
+            p.requires_grad = True
+
+    def train(self, mode: bool = True):
+        super().train(mode)
+        if self._embedder_frozen:
+            self.feature_extractor.eval()
+        return self

--- a/src/multimeditron/model/modalities/volume/volume_processor.py
+++ b/src/multimeditron/model/modalities/volume/volume_processor.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from multimeditron.model.constants import MODALITY_VALUE_KEY, NUM_EMBEDDINGS_KEY
+from multimeditron.model.modalities.base import BaseModalityProcessor
+
+
+class VolumeProcessor(BaseModalityProcessor):
+    """
+    Processor for 3D volumes.
+
+    Responsibilities:
+    - Accept numpy arrays from loaders
+    - Normalize shape to (C, D, H, W)
+    - Cast to float
+    - Resize to target volume_size
+    - Min-max normalize to [0, 1]
+    """
+
+    def __init__(self, config: Any):
+        super().__init__(config)
+
+        if not hasattr(config, "volume_size"):
+            raise ValueError("VolumeProcessor requires config.volume_size")
+        if len(config.volume_size) != 3:
+            raise ValueError(
+                f"config.volume_size must be a 3-tuple (D, H, W), got: {config.volume_size}"
+            )
+        self.volume_size: Tuple[int, int, int] = tuple(int(x) for x in config.volume_size)
+
+        # Number of multimodal tokens inserted into prompt.
+        # For volume models this is typically set by config (e.g. after pooling).
+        self._num_embeddings = int(getattr(config, "proj_out_num", 1))
+        if self._num_embeddings <= 0:
+            raise ValueError("config.proj_out_num must be > 0")
+
+    def _to_chw3d(self, arr: np.ndarray) -> np.ndarray:
+        """
+        Convert array to channel-first (C, D, H, W).
+
+        Accepted inputs:
+        - (D, H, W): single-channel volume
+        - (C, D, H, W): channel-first volume
+        - (D, H, W, C): channel-last volume (C must be small, e.g. 1/3/4)
+        """
+        if arr.ndim == 3:
+            return arr[None, ...]
+
+        if arr.ndim != 4:
+            raise ValueError(
+                f"Expected 3D or 4D volume array, got shape {arr.shape} (ndim={arr.ndim})"
+            )
+
+        c_first = arr.shape[0] in (1, 3, 4)
+        c_last = arr.shape[-1] in (1, 3, 4)
+
+        if c_first and not c_last:
+            return arr
+        if c_last and not c_first:
+            return np.moveaxis(arr, -1, 0)
+        if c_first and c_last:
+            # Ambiguous case like (1, D, H, 1): keep as channel-first by convention.
+            return arr
+
+        raise ValueError(
+            "For 4D input, expected channel dimension to be first or last "
+            f"with size in (1,3,4), got shape {arr.shape}"
+        )
+
+    def process(self, modality: Dict[str, Any]) -> Dict[str, Any]:
+        processed = modality.copy()
+        volume = modality.get(MODALITY_VALUE_KEY, None)
+
+        if not isinstance(volume, np.ndarray):
+            raise ValueError(
+                f"VolumeProcessor expects numpy.ndarray at '{MODALITY_VALUE_KEY}', got {type(volume)}"
+            )
+
+        volume = self._to_chw3d(volume)
+        tensor = torch.from_numpy(volume).float()  # (C, D, H, W)
+
+        if not torch.isfinite(tensor).all():
+            raise ValueError("Volume contains non-finite values (NaN or Inf)")
+
+        # Resize in 3D: interpolate expects (N, C, D, H, W).
+        tensor = F.interpolate(
+            tensor.unsqueeze(0),
+            size=self.volume_size,
+            mode="trilinear",
+            align_corners=False,
+        ).squeeze(0)
+
+        # Min-max normalize each volume to [0, 1].
+        v_min = torch.amin(tensor)
+        v_max = torch.amax(tensor)
+        if float(v_max - v_min) > 0:
+            tensor = (tensor - v_min) / (v_max - v_min)
+        else:
+            tensor = torch.zeros_like(tensor)
+
+        processed[MODALITY_VALUE_KEY] = tensor
+        processed[NUM_EMBEDDINGS_KEY] = self._num_embeddings
+        return processed

--- a/src/multimeditron/model/modalities/volume/volume_processor.py
+++ b/src/multimeditron/model/modalities/volume/volume_processor.py
@@ -82,18 +82,25 @@ class VolumeProcessor(BaseModalityProcessor):
             )
 
         volume = self._to_chw3d(volume)
+        if volume.shape[0] != 1:
+            raise ValueError(
+                "M3D-CLIP expects single-channel 3D volumes with shape (1, D, H, W); "
+                f"got channel count {volume.shape[0]} from shape {volume.shape}"
+            )
+
         tensor = torch.from_numpy(volume).float()  # (C, D, H, W)
 
         if not torch.isfinite(tensor).all():
             raise ValueError("Volume contains non-finite values (NaN or Inf)")
 
-        # Resize in 3D: interpolate expects (N, C, D, H, W).
-        tensor = F.interpolate(
-            tensor.unsqueeze(0),
-            size=self.volume_size,
-            mode="trilinear",
-            align_corners=False,
-        ).squeeze(0)
+        # Resize in 3D only when needed; preprocessed MedMNIST volumes already match this.
+        if tuple(tensor.shape[-3:]) != self.volume_size:
+            tensor = F.interpolate(
+                tensor.unsqueeze(0),
+                size=self.volume_size,
+                mode="trilinear",
+                align_corners=False,
+            ).squeeze(0)
 
         # Min-max normalize each volume to [0, 1].
         v_min = torch.amin(tensor)

--- a/src/multimeditron/model/model.py
+++ b/src/multimeditron/model/model.py
@@ -119,6 +119,7 @@ class MultimodalConfig(PretrainedConfig):
         truncation: bool = False,
         max_sequence_length: Optional[int] = None,
         dtype="bfloat16",
+        attn_implementation: str = "flash_attention_2",
         **kwargs
     ):
         """
@@ -146,6 +147,7 @@ class MultimodalConfig(PretrainedConfig):
         self.initializer_range = initializer_range
         self.llm_path = llm_path
         self.dtype = dtype
+        self.attn_implementation = attn_implementation
         self.truncation = truncation
         self.max_sequence_length = max_sequence_length
 
@@ -249,15 +251,20 @@ class MultiModalModelForCausalLM(PreTrainedModel):
 
         dtype = get_torch_dtype(config.dtype)
 
+        attn_implementation = getattr(config, "attn_implementation", "flash_attention_2")
         if bootstrap:
-            self.model = AutoModelForCausalLM.from_pretrained(config.llm_path, attn_implementation="flash_attention_2")
+            self.model = AutoModelForCausalLM.from_pretrained(
+                config.llm_path,
+                torch_dtype=dtype,
+                attn_implementation=attn_implementation,
+            )
         else:
             llm_config = AutoConfig.from_pretrained(
                     config.llm_path,
                     torch_dtype=dtype
                 )
             self.model = AutoModelForCausalLM.from_config(
-                config=llm_config, attn_implementation="eager")
+                config=llm_config, attn_implementation=attn_implementation)
 
         self.model.resize_token_embeddings(config.vocab_size, mean_resizing=False)
 
@@ -281,8 +288,9 @@ class MultiModalModelForCausalLM(PreTrainedModel):
             self.processors_by_type[modality_config.modality_type] = processor
             self.modalities_with_projection.append(modality)
 
-        # Post init
-        self.post_init()
+        # Do not call PreTrainedModel.post_init() here: the LLM and modality
+        # encoders are already initialized by their own constructors, and a
+        # recursive post_init would reinitialize pretrained Linear/Embedding weights.
 
     def _init_weights(self, module):
         """
@@ -710,6 +718,7 @@ def bootstrap(config, tokenizer, modalities_config):
         llm_path=config["base_llm"],
         truncation=config.get("truncation", False),
         max_sequence_length=config.get("max_sequence_length", None),
+        attn_implementation=config.get("attn_implementation", "flash_attention_2"),
     )
 
     model = MultiModalModelForCausalLM(


### PR DESCRIPTION
## Summary

This PR adds native 3D medical volume support for Stage-1 alignment experiments.

- [x] Added 3D volume dataset loaders:
  - `fs-volume` for loading `.npy` volumes from filesystem paths.
  - `raw-volume` for loading in-memory / Arrow-style volume payloads.
- [x] Added `VolumeProcessor` for 3D medical volume preprocessing:
  - accepts `.npy` volume arrays.
  - normalizes to `[0, 1]`.
  - resizes to `(1, 32, 256, 256)` contract.
- [x] Added `VolumeConfig`:
  - default encoder: `GoodBaiBai88/M3D-CLIP`.
  - `volume_size=(32,256,256)`.
  - `patch_size=(4,16,16)`.
  - `pool_factor=(2,2,2)`.
  - validates derived token path: `2048 -> 256`.
- [x] Added `volume_3d` modality:
  - loads a pretrained 3D vision encoder.
  - supports `encode_image()` or `vision_model(...).last_hidden_state`.
  - uses M3D-style 3D spatial pooling from `2048` patch tokens to `256` visual tokens.
  - keeps the MultiMeditron `MLPProjector` for mapping encoder features to LLM hidden size.
- [x] Added Stage-1 alignment cookbook config:
  - freezes the LLM.
  - freezes the 3D vision encoder.
  - trains only the projector.
- [x] Updated dataset checking support for 3D image modality inputs.

## Validation

- [x] Config/grid smoke test:
  - `(32,256,256)` with patch `(4,16,16)` produces `(8,16,16) -> (4,8,8)`.
  - `proj_out_num=256`.
- [x] Spatial pooling smoke test:
  - input tokens: `(2,2048,768)`.
  - output tokens: `(2,256,768)`.
- [x] Real M3D-CLIP forward smoke test:
  - output shape: `(1,256,4096)`.
- [x] 3D MedMNIST validation completed (on NoduleMNIST3D)
- [x] Training/eval completed successfully with:
  - TinyLlama/TinyLlama-1.1B-Chat-v1.0
  - EPFLiGHT/Meditron3-Gemma2-2B


## Training with a Dataset Status

The original M3D alignment dataset, [M3D-Cap](https://huggingface.co/datasets/GoodBaiBai88/M3D-Cap), currently shows disabled access due to a DMCA/licensing discussion: [M3D-Cap discussion #4](https://huggingface.co/datasets/GoodBaiBai88/M3D-Cap/discussions/4).

For follow-up alignment experiments, [CT-RATE](https://huggingface.co/datasets/ibrahimhamamci/CT-RATE) is a practical open alternative because it provides 3D chest CT volumes paired with radiology text reports. CT-RATE is suitable for projector alignment experiments where the LLM and vision encoder are frozen and only the projector is trained.

## Spatial pooling

```
Input volume: 32 × 256 × 256
Patch size:   4 × 16 × 16

Patch grid:
32/4   = 8
256/16 = 16
256/16 = 16

So total patch tokens:
8 × 16 × 16 = 2048 tokens
```
after the 3D encoder:
```
2048 visual tokens, each token has 768 features
Shape: 2048 × 768
```
Then 3D spatial pooling reduces the spatial grid:
```
8 × 16 × 16  →  4 × 8 × 8
```
So token count becomes:
```
4 × 8 × 8 = 256 tokens
```
After spatial pooling:
```
256 visual tokens, each token still has 768 features
Shape: 256 × 768
```
M3D-CLIP outputs:
```
hidden size = 768
```
But Llama-3.1-8B uses:
```
hidden size = 4096
```
So the MLP projector converts each visual token from M3D-CLIP space into Llama embedding space:
```
768 → 4096
```

## References

- M3D paper: [M3D: Advancing 3D Medical Image Analysis with Multi-Modal Large Language Models](https://arxiv.org/abs/2404.00578)
- M3D-Cap dataset: [GoodBaiBai88/M3D-Cap](https://huggingface.co/datasets/GoodBaiBai88/M3D-Cap)
- M3D-Cap licensing discussion: [Discussion #4](https://huggingface.co/datasets/GoodBaiBai88/M3D-Cap/discussions/4)
- CT-RATE dataset: [ibrahimhamamci/CT-RATE](https://huggingface.co/datasets/ibrahimhamamci/CT-RATE)
- CT-RATE paper: [A foundation model utilizing chest CT volumes and radiology reports for supervised-level zero-shot detection of abnormalities](https://arxiv.org/abs/2403.17834)
- [3D MedMINIST dataset](https://medmnist.com/)